### PR TITLE
Removed load_boston

### DIFF
--- a/week2/regression_stumps.py
+++ b/week2/regression_stumps.py
@@ -1,5 +1,4 @@
 import numpy as np
-from sklearn.datasets import load_boston
 from sklearn.model_selection import train_test_split
 import pdb 
 from sklearn.tree import DecisionTreeRegressor


### PR DESCRIPTION
load_boston has been removed from sklearn library, and including the import gives an ImportError.